### PR TITLE
[FIX] - Add automatic download resumption and improve settings UX

### DIFF
--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -662,8 +662,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
         const SizedBox(height: 16),
         Semantics(
-          button: true,
-          label: 'Set download location',
+          label: 'Download location',
           child: ListTile(
             leading: const Icon(Icons.folder),
             title: Text(localizations?.downloadLocationTitle ??
@@ -718,20 +717,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (Platform.isAndroid)
-                  IconButton(
-                    icon: const Icon(Icons.help_outline),
-                    onPressed: () => _showFolderSelectionInstructions(context),
-                    tooltip: 'Show instructions',
+                  Semantics(
+                    button: true,
+                    label: 'Show folder selection instructions',
+                    child: IconButton(
+                      icon: const Icon(Icons.help_outline),
+                      onPressed: () =>
+                          _showFolderSelectionInstructions(context),
+                      tooltip: 'Show instructions',
+                    ),
                   ),
-                if (_downloadFolderPath != null)
-                  IconButton(
+                Semantics(
+                  button: true,
+                  label: 'Change download folder',
+                  child: IconButton(
                     icon: const Icon(Icons.edit),
                     onPressed: () => _selectDownloadFolder(context),
                     tooltip: 'Change folder',
                   ),
+                ),
               ],
             ),
-            onTap: () => _selectDownloadFolder(context),
           ),
         ),
         ListTile(


### PR DESCRIPTION
Implement automatic download resumption when app returns to foreground and enhance settings screen to prevent accidental file picker opening.

Download Management:
- Add automatic resumption of restored downloads in _onAppResumed()
- Save download progress and status to metadata every 5 seconds
- Restore progress from metadata when displaying restored downloads
- Add comprehensive logging for download resumption operations
- Handle errors individually for each download during auto-resume

Settings Screen:
- Remove onTap handler from download location ListTile
- Keep only "Edit" button for manual folder selection
- Improve accessibility with proper Semantics labels for buttons
- Prevent automatic file picker opening when opening settings

Technical Details:
- Track lastSaveTime in _updateProgress() to avoid database spam
- Save progress, status, downloadedBytes, totalBytes, and lastUpdated
- Restore progress and status from metadata in getActiveDownloads()
- Filter restored downloads by status 'restored' and isActive flag
- Initialize torrent manager with database before resuming downloads;