### PR TITLE
[FEATURE] - Refactor favorites to Riverpod and add favorite buttons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,43 +214,43 @@ build-android-signed-apk: use-existing-android-cert patch-gradle-signing patch-g
 
 .PHONY: copy-apk
 copy-apk:
-	@echo "Copying APK files with version $(FULL_VERSION)..."
+	@echo "Copying APK files with version $(VERSION) (without build number)..."
 	@mkdir -p $(APK_DEST_DIR)
 	@echo "Copying split APKs (per architecture)..."
 	@if [ -f "build/app/outputs/flutter-apk/app-x86_64-release.apk" ]; then \
-		cp -f build/app/outputs/flutter-apk/app-x86_64-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_x86_64.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_x86_64.apk"; \
+		cp -f build/app/outputs/flutter-apk/app-x86_64-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_x86_64.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_x86_64.apk"; \
 	elif [ -f "build/app/outputs/apk/release/app-x86_64-release.apk" ]; then \
-		cp -f build/app/outputs/apk/release/app-x86_64-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_x86_64.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_x86_64.apk"; \
+		cp -f build/app/outputs/apk/release/app-x86_64-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_x86_64.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_x86_64.apk"; \
 	else \
 		echo "⚠️  Warning: app-x86_64-release.apk not found"; \
 	fi
 	@if [ -f "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk" ]; then \
-		cp -f build/app/outputs/flutter-apk/app-arm64-v8a-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_v8a.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_v8a.apk"; \
+		cp -f build/app/outputs/flutter-apk/app-arm64-v8a-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_v8a.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_v8a.apk"; \
 	elif [ -f "build/app/outputs/apk/release/app-arm64-v8a-release.apk" ]; then \
-		cp -f build/app/outputs/apk/release/app-arm64-v8a-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_v8a.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_v8a.apk"; \
+		cp -f build/app/outputs/apk/release/app-arm64-v8a-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_v8a.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_v8a.apk"; \
 	else \
 		echo "⚠️  Warning: app-arm64-v8a-release.apk not found"; \
 	fi
 	@if [ -f "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk" ]; then \
-		cp -f build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_v7a.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_v7a.apk"; \
+		cp -f build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_v7a.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_v7a.apk"; \
 	elif [ -f "build/app/outputs/apk/release/app-armeabi-v7a-release.apk" ]; then \
-		cp -f build/app/outputs/apk/release/app-armeabi-v7a-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_v7a.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_v7a.apk"; \
+		cp -f build/app/outputs/apk/release/app-armeabi-v7a-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_v7a.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_v7a.apk"; \
 	else \
 		echo "⚠️  Warning: app-armeabi-v7a-release.apk not found"; \
 	fi
 	@echo "Copying universal APK (all architectures)..."
 	@if [ -f "build/app/outputs/flutter-apk/app-release.apk" ]; then \
-		cp -f build/app/outputs/flutter-apk/app-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_universal.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_universal.apk"; \
+		cp -f build/app/outputs/flutter-apk/app-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_universal.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_universal.apk"; \
 	elif [ -f "build/app/outputs/apk/release/app-release.apk" ]; then \
-		cp -f build/app/outputs/apk/release/app-release.apk $(APK_DEST_DIR)/Jabook_$(FULL_VERSION)_universal.apk && \
-		echo "✅ Copied: Jabook_$(FULL_VERSION)_universal.apk"; \
+		cp -f build/app/outputs/apk/release/app-release.apk $(APK_DEST_DIR)/Jabook_$(VERSION)_universal.apk && \
+		echo "✅ Copied: Jabook_$(VERSION)_universal.apk"; \
 	else \
 		echo "⚠️  Warning: app-release.apk (universal) not found"; \
 	fi

--- a/hack/update-version.sh
+++ b/hack/update-version.sh
@@ -71,13 +71,29 @@ if [ $# -ge 1 ]; then
         NEW_BUILD=$((CURRENT_BUILD + 1))
     fi
 else
-    # Auto-increment patch version
+    # Auto-increment version with rollover logic
+    # Format: major.minor.bugfix, each part goes up to 9
+    # 1.1.9 -> 1.2.0
+    # 1.9.9 -> 2.0.0
     MAJOR=$(echo "${CURRENT_VERSION}" | cut -d. -f1)
     MINOR=$(echo "${CURRENT_VERSION}" | cut -d. -f2)
     PATCH=$(echo "${CURRENT_VERSION}" | cut -d. -f3)
     
-    # Increment patch version
-    PATCH=$((PATCH + 1))
+    # Increment with rollover logic
+    if [ "${PATCH}" -lt 9 ]; then
+        # Increment patch version
+        PATCH=$((PATCH + 1))
+    elif [ "${MINOR}" -lt 9 ]; then
+        # Patch reached 9, increment minor, reset patch to 0
+        MINOR=$((MINOR + 1))
+        PATCH=0
+    else
+        # Minor reached 9, increment major, reset minor and patch to 0
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+    fi
+    
     NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
     
     # Increment build number

--- a/lib/core/favorites/favorites_provider.dart
+++ b/lib/core/favorites/favorites_provider.dart
@@ -1,0 +1,156 @@
+// Copyright 2025 Jabook Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jabook/core/endpoints/endpoint_provider.dart';
+import 'package:jabook/core/favorites/favorites_service.dart';
+import 'package:jabook/core/parse/rutracker_parser.dart';
+import 'package:riverpod/legacy.dart';
+
+/// Provider for FavoritesService instance.
+///
+/// This provider creates and provides a FavoritesService instance
+/// using the app database. The database must be initialized before use.
+final favoritesServiceProvider = Provider<FavoritesService?>((ref) {
+  try {
+    final appDatabase = ref.watch(appDatabaseProvider);
+    if (appDatabase.isInitialized) {
+      return FavoritesService(appDatabase.database);
+    }
+    return null;
+  } on Exception {
+    return null;
+  }
+}, dependencies: [appDatabaseProvider]);
+
+/// Provider for favorite audiobook IDs set.
+///
+/// This provider manages the set of favorite audiobook topic IDs
+/// and automatically syncs with the database.
+final favoriteIdsProvider =
+    StateNotifierProvider<FavoriteIdsNotifier, Set<String>>((ref) {
+  final service = ref.watch(favoritesServiceProvider);
+  return FavoriteIdsNotifier(service);
+});
+
+/// Provider for all favorite audiobooks list.
+///
+/// This provider automatically loads and refreshes the list of favorite audiobooks
+/// when the favoriteIdsProvider changes.
+final favoritesListProvider = FutureProvider<List<Audiobook>>((ref) async {
+  final service = ref.watch(favoritesServiceProvider);
+  if (service == null) {
+    return [];
+  }
+
+  // Watch favoriteIds to trigger refresh when favorites change
+  ref.watch(favoriteIdsProvider);
+
+  try {
+    return await service.getAllFavorites();
+  } on Exception {
+    return [];
+  }
+});
+
+/// Notifier for managing favorite IDs state.
+///
+/// This notifier maintains a set of favorite audiobook topic IDs
+/// and syncs with the database.
+class FavoriteIdsNotifier extends StateNotifier<Set<String>> {
+  /// Creates a new FavoriteIdsNotifier instance.
+  FavoriteIdsNotifier(this._service) : super(<String>{}) {
+    _loadFavoriteIds();
+  }
+
+  /// FavoritesService instance (may be null if database not initialized).
+  final FavoritesService? _service;
+
+  /// Loads favorite IDs from the database.
+  Future<void> _loadFavoriteIds() async {
+    if (_service == null) return;
+
+    try {
+      final favorites = await _service.getAllFavorites();
+      state = favorites.map((a) => a.id).toSet();
+    } on Exception {
+      state = <String>{};
+    }
+  }
+
+  /// Toggles favorite status for an audiobook.
+  ///
+  /// The [topicId] parameter is the topic ID of the audiobook.
+  /// The [audiobookMap] parameter is optional audiobook data in Map format.
+  /// If provided, it will be used when adding to favorites.
+  ///
+  /// Returns true if added to favorites, false if removed.
+  Future<bool> toggleFavorite(
+    String topicId, {
+    Map<String, dynamic>? audiobookMap,
+  }) async {
+    if (_service == null) return false;
+
+    final isCurrentlyFavorite = state.contains(topicId);
+    final newState = <String>{...state};
+
+    // Optimistic update
+    if (isCurrentlyFavorite) {
+      newState.remove(topicId);
+    } else {
+      newState.add(topicId);
+    }
+    state = newState;
+
+    try {
+      if (isCurrentlyFavorite) {
+        // Remove from favorites
+        await _service.removeFromFavorites(topicId);
+        return false;
+      } else {
+        // Add to favorites
+        if (audiobookMap != null) {
+          await _service.addToFavoritesFromMap(audiobookMap);
+        } else {
+          // If no audiobookMap provided, we can't add to favorites
+          // Revert optimistic update
+          state = <String>{...state}..remove(topicId);
+          return false;
+        }
+        return true;
+      }
+    } on Exception {
+      // Revert optimistic update on error
+      state = <String>{...state};
+      if (isCurrentlyFavorite) {
+        state.add(topicId);
+      } else {
+        state.remove(topicId);
+      }
+      rethrow;
+    }
+  }
+
+  /// Refreshes favorite IDs from the database.
+  Future<void> refresh() async {
+    await _loadFavoriteIds();
+  }
+
+  /// Checks if an audiobook is in favorites.
+  ///
+  /// The [topicId] parameter is the topic ID to check.
+  ///
+  /// Returns true if the audiobook is in favorites, false otherwise.
+  bool isFavorite(String topicId) => state.contains(topicId);
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1328,6 +1328,10 @@
   "@goToSearchButton": {
     "description": "Button to navigate to search"
   },
+  "addedToFavorites": "Added to favorites",
+  "@addedToFavorites": {
+    "description": "Message when added to favorites"
+  },
   "removedFromFavorites": "Removed from favorites",
   "@removedFromFavorites": {
     "description": "Message when removed from favorites"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1883,6 +1883,12 @@ abstract class AppLocalizations {
   /// **'Go to Search'**
   String get goToSearchButton;
 
+  /// Message when added to favorites
+  ///
+  /// In en, this message translates to:
+  /// **'Added to favorites'**
+  String get addedToFavorites;
+
   /// Message when removed from favorites
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -957,6 +957,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get goToSearchButton => 'Go to Search';
 
   @override
+  String get addedToFavorites => 'Added to favorites';
+
+  @override
   String get removedFromFavorites => 'Removed from favorites';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -957,6 +957,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get goToSearchButton => 'Перейти к поиску';
 
   @override
+  String get addedToFavorites => 'Добавлено в избранное';
+
+  @override
   String get removedFromFavorites => 'Удалено из избранного';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1313,6 +1313,10 @@
   "@goToSearchButton": {
     "description": "Кнопка для перехода к поиску"
   },
+  "addedToFavorites": "Добавлено в избранное",
+  "@addedToFavorites": {
+    "description": "Сообщение при добавлении в избранное"
+  },
   "removedFromFavorites": "Удалено из избранного",
   "@removedFromFavorites": {
     "description": "Сообщение при удалении из избранного"


### PR DESCRIPTION
Refactor favorites system to use Riverpod providers for better state management and add favorite toggle buttons to player and topic screens.

- Add favorites_provider.dart with Riverpod providers for favorites state
- Refactor favorites_screen.dart to use Riverpod providers instead of direct service calls
- Refactor search_screen.dart to use Riverpod providers for favorites
- Add favorite toggle button to player_screen.dart
- Add favorite toggle button to topic_screen.dart
- Add "addedToFavorites" localization string
- Update Makefile to use VERSION instead of FULL_VERSION in copy-apk target
- Improve version rollover logic in update-version.sh (1.1.9 -> 1.2.0, 1.9.9 -> 2.0.0);